### PR TITLE
GitHub Actions workflow for building cc1 builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,55 @@
+name: Compile cc1
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: ${{ matrix.TARGET.OS }}
+    strategy:
+      fail-fast: false
+      matrix:
+        TARGET:
+          - {
+              OS: 'ubuntu-latest',
+              CFLAGS: '-std=gnu89 -m32 -static',
+              HOST: 'i386-pc-linux'
+            }
+          - {
+              OS: 'macos-latest',
+              CFLAGS: '-std=gnu89 -Wno-return-type -Wno-error -Wno-implicit-function-declaration',
+              HOST: 'i386-apple-darwin'
+            }
+
+    name: Building cc1 for ${{ matrix.TARGET.OS }}
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install dependencies (Ubuntu)
+        shell: bash
+        if: matrix.TARGET.OS == 'ubuntu-latest'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y build-essential bison file gcc-multilib gperf
+
+      - name: Configure
+        shell: bash
+        run: |
+          ./configure --target=mips-nintendo-nu64 --prefix=/opt/cross --disable-gprof --disable-gdb --disable-werror --host=${{ matrix.TARGET.HOST }} --build=${{ matrix.TARGET.HOST }}
+
+      - name: Make
+        continue-on-error: true
+        shell: bash
+        run: |
+          make CFLAGS="${{ matrix.TARGET.CFLAGS }}"
+
+      - name: Test for file
+        shell: bash
+        run: |
+          test -f cc1
+          file cc1
+
+      - name: Upload output
+        uses: actions/upload-artifact@v2
+        with:
+          name: cc1-${{ matrix.TARGET.OS }}
+          path: cc1

--- a/PAPERMARIO.md
+++ b/PAPERMARIO.md
@@ -1,5 +1,27 @@
-The 32-bit cc1 in the papermario repo was built with CFLAGS="-m32 -static"
+To build the 32-bit static cc1 in the [papermario](https://github.com/ethteck/papermario) repo on Ubuntu, use:
 
-The 64-bit cc1 can be built with the following commands:
-`./configure --target=mips-nintendo-nu64 --host=i386-apple-darwin --prefix=/opt/cross --disable-gprof --disable-gdb`
-`make CFLAGS="-std=gnu89 -Wno-return-type -Wno-error -Wno-implicit-function-declaration"`
+> Install dependencies:
+> ```bash
+> apt-get update
+> apt-get install build-essential bison file gcc-multilib gperf
+> ```
+> Configure:
+> ```bash
+> ./configure --target=mips-nintendo-nu64 --prefix=/opt/cross --disable-gprof --disable-gdb --disable-werror --host=i386-pc-linux --build=i386-pc-linux
+> ```
+> Make:
+> ```bash
+> make CFLAGS="-std=gnu89 -m32 -static"
+> ```
+> The `make` stage may fail, but this is fine as long as the `cc1` binary is created successfully.
+
+To build the 64-bit cc1 for macOS, use:
+> Configure:
+> ```bash
+> ./configure --target=mips-nintendo-nu64 --prefix=/opt/cross --disable-gprof --disable-gdb --disable-werror --host=i386-apple-darwin --build=i386-apple-darwin
+> ```
+> Make:
+> ```bash
+> make CFLAGS="-std=gnu89 -Wno-return-type -Wno-error -Wno-implicit-function-declaration"
+> ```
+> The `make` stage may fail, but this is fine as long as the `cc1` binary is created successfully.


### PR DESCRIPTION
This adds a GitHub Actions workflow that executes on repo push to build our current known working Ubuntu and macOS builds of `cc1`.

This means that if we ever find more patches to make, GitHub will just build the new versions for us, and it serves as a transparent sanity check that the instructions to build it are actually correct.